### PR TITLE
Fixed background color on large screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -23,6 +23,10 @@ body {
 	color:#656565;
 }
 
+html {
+	background:#fcfcfc;
+}
+
 
 
 a:active {


### PR DESCRIPTION
On larger screens, since the footer got pushed down to the bottom of the page and the background color was only on the body, not the footer, the background color wasn't continuing to the footer. This fixes that.